### PR TITLE
Garbage reduction and make GC toggleable

### DIFF
--- a/GrumpyCollector.cs
+++ b/GrumpyCollector.cs
@@ -15,12 +15,13 @@ namespace GrumpyCollector
         private Rect windowPos = new Rect(40, 40, 150, 46);
         private Rect windowDragRect = new Rect(0, 0, 150, 46);
 
-        private Rect labelRectInterval = new Rect(10, 18, 70, 20);
-        private Rect labelRectRate = new Rect(90, 18, 50, 20);
+        private Rect labelRectInterval = new Rect(10, 18, 80, 20);
+        private Rect labelRectRate = new Rect(92, 18, 48, 20);
 
         private float interval = 0f;
         private string strInterval;
 
+        [Persistent] private bool enableGC = false;
         [Persistent] private int intervalIdx = 2;
 
         private float lastGC = 0;
@@ -56,6 +57,10 @@ namespace GrumpyCollector
                 {
                     showUI = !showUI;
                 }
+                if (Input.GetKeyDown(KeyCode.KeypadDivide))
+                {
+                    enableGC = !enableGC;
+                }
                 if (Input.GetKeyDown(KeyCode.KeypadPlus))
                 {
                     intervalIdx--;
@@ -76,7 +81,7 @@ namespace GrumpyCollector
                 }
             }
 
-            if (showUI && Time.realtimeSinceStartup > lastGC + interval)
+            if (enableGC && (Time.realtimeSinceStartup > lastGC + interval))
             {
                 GC.Collect(0, GCCollectionMode.Forced);
                 lastGC = Time.realtimeSinceStartup;
@@ -97,7 +102,7 @@ namespace GrumpyCollector
 
         public void WindowGUI(int windowID)
         {
-            GUI.Label(labelRectInterval, "GC Interval:");
+            GUI.Label(labelRectInterval, enableGC ? "GC Enabled:" : "GC Disabled:");
             GUI.Label(labelRectRate, strInterval);
             GUI.DragWindow(windowDragRect);
         }

--- a/GrumpyCollector.cs
+++ b/GrumpyCollector.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using KSP.IO;
 using UnityEngine;
 
@@ -7,26 +8,34 @@ namespace GrumpyCollector
     [KSPAddon(KSPAddon.Startup.Instantly, false)]
     public class GrumpyCollector : MonoBehaviour
     {
-
         private const string cfgName = "GrumpyCollector.cfg";
 
         private bool showUI = false;
 
-        private Rect windowPos = new Rect(40, 40, 50, 50);
+        private Rect windowPos = new Rect(40, 40, 150, 46);
+        private Rect windowDragRect = new Rect(0, 0, 150, 46);
 
-        private float interval = 0.5f;
+        private Rect labelRectInterval = new Rect(10, 18, 70, 20);
+        private Rect labelRectRate = new Rect(90, 18, 50, 20);
+
+        private float interval = 0f;
+        private string strInterval;
 
         [Persistent] private int intervalIdx = 2;
 
         private float lastGC = 0;
 
+        private StringBuilder strBuild;
+
         internal void Awake()
         {
             DontDestroyOnLoad(gameObject);
 
+            strBuild = new StringBuilder(32);
+
             if (File.Exists<GrumpyCollector>(cfgName))
             {
-                ConfigNode config = ConfigNode.Load(IOUtils.GetFilePathFor(this.GetType(), cfgName));
+                ConfigNode config = ConfigNode.Load(IOUtils.GetFilePathFor(GetType(), cfgName));
                 ConfigNode.LoadObjectFromConfig(this, config);
             }
             SetInterval();
@@ -36,17 +45,38 @@ namespace GrumpyCollector
         {
             ConfigNode node = new ConfigNode("GrumpyCollector");
             ConfigNode.CreateConfigFromObject(this, node);
-            node.Save(IOUtils.GetFilePathFor(this.GetType(), cfgName));
+            node.Save(IOUtils.GetFilePathFor(GetType(), cfgName));
         }
 
         void Update()
         {
-            SetInterval();
-            if (Input.GetKey(KeyCode.LeftControl) && Input.GetKeyDown(KeyCode.KeypadMultiply))
+            if (Input.GetKey(KeyCode.LeftControl))
             {
-                showUI = !showUI;
+                if (Input.GetKeyDown(KeyCode.KeypadMultiply))
+                {
+                    showUI = !showUI;
+                }
+                if (Input.GetKeyDown(KeyCode.KeypadPlus))
+                {
+                    intervalIdx--;
+                    if (intervalIdx == 0)
+                        intervalIdx = -2;
+                    else if (intervalIdx < -10)
+                        intervalIdx = -10;
+                    SetInterval();
+                }
+                if (Input.GetKeyDown(KeyCode.KeypadMinus))
+                {
+                    intervalIdx++;
+                    if (intervalIdx == 0)
+                        intervalIdx = 2;
+                    else if (intervalIdx > 10)
+                        intervalIdx = 10;
+                    SetInterval();
+                }
             }
-            if (Time.realtimeSinceStartup > lastGC + interval)
+
+            if (showUI && Time.realtimeSinceStartup > lastGC + interval)
             {
                 GC.Collect(0, GCCollectionMode.Forced);
                 lastGC = Time.realtimeSinceStartup;
@@ -57,58 +87,32 @@ namespace GrumpyCollector
         {
             if (showUI)
             {
-                windowPos = GUILayout.Window(
+                windowPos = GUI.Window(
                     8785499,
                     windowPos,
                     WindowGUI,
-                    "GrumpyCollector",
-                    GUILayout.ExpandWidth(true),
-                    GUILayout.ExpandHeight(true));
+                    "GrumpyCollector");
             }
         }
 
         public void WindowGUI(int windowID)
         {
-            GUILayout.BeginVertical();
-
-            GUILayout.Label("Forced Garbage Interval");
-
-            GUILayout.BeginHorizontal();
-
-            if (GUILayout.Button("Faster", GUILayout.ExpandWidth(true)))
-            {
-                intervalIdx++;
-                if (intervalIdx == 0)
-                    intervalIdx = 2;
-            }
-
-            GUILayout.Label(string.Format("{0} s", interval.ToString("F3")), GUILayout.ExpandWidth(true));
-
-            if (GUILayout.Button("Slower", GUILayout.ExpandWidth(true)))
-            {
-                intervalIdx--;
-                if (intervalIdx == 0)
-                    intervalIdx = -2;
-            }
-
-            intervalIdx = Mathf.Clamp(intervalIdx, -10, 10);
-
-            GUILayout.EndHorizontal();
-
-            GUILayout.EndVertical();
-
-            GUI.DragWindow();
+            GUI.Label(labelRectInterval, "GC Interval:");
+            GUI.Label(labelRectRate, strInterval);
+            GUI.DragWindow(windowDragRect);
         }
 
         private void SetInterval()
         {
-            if (intervalIdx > 0)
+            float newinterval = (intervalIdx > 0) ? 1f / intervalIdx : -intervalIdx;
+            if (newinterval != interval)
             {
-                interval = 1f / intervalIdx;
-            }
-            else
-            {
-                interval = -intervalIdx;
+                interval = newinterval;
+                strBuild.Length = 0;
+                strBuild.Append(interval);
+                strBuild.Length = (interval == 10f) ? 6 : 5;
+                strBuild.Append(" s");
+                strInterval = strBuild.ToString();
             }
         }
     }


### PR DESCRIPTION
Made timed garbage collections only happen if window is shown.
Various changes to reduce garbage creation:
Switched from GUILayout to GUI
Replaced buttons with Ctrl-NumPadPlus and Ctrl-NumPadMinus hotkeys
Only update rate string when necessary to avoid a boxing, a ToString call and a string.Format all of which allocate an object
Build rate string by careful use of a StringBuilder so only the final string is allocated

These may be rather controversial changes but, given it is basically an experimental tool, I don't really see any harm in significantly changing how the UI works...
